### PR TITLE
Update mitmproxy to 2.0.0

### DIFF
--- a/Casks/mitmproxy.rb
+++ b/Casks/mitmproxy.rb
@@ -1,16 +1,17 @@
 cask 'mitmproxy' do
-  version '1.0.2'
-  sha256 '5752b482f7dc574b3f1f96c4bac1508c05b80a751f7e65bdf4900a1b1d891977'
+  version '2.0.0'
+  sha256 'cc64ac5f797ee001b54b4df4de1cc67c751ea94bb0878b2cc1fb254dc3a3daf4'
 
   # github.com/mitmproxy/mitmproxy was verified as official when first introduced to the cask
   url "https://github.com/mitmproxy/mitmproxy/releases/download/v#{version}/mitmproxy-#{version}-osx.tar.gz"
   appcast 'https://github.com/mitmproxy/mitmproxy/releases.atom',
-          checkpoint: '828f72c285d93fa503b16bf0223e27cd5bb7ddbcfc87614956c6f9e693df119e'
+          checkpoint: '0e98977e1d2e343c57111de6e76cb9ae29291b03ab2c0544c17ec923db1a914d'
   name 'mitmproxy'
   homepage 'https://mitmproxy.org/'
+
   license :mit
 
-  binary "mitmproxy"
-  binary "mitmdump"
-  binary "mitmweb"
+  binary 'mitmproxy'
+  binary 'mitmdump'
+  binary 'mitmweb'
 end


### PR DESCRIPTION
- [x] `brew cask audit --download {{cask_file}}` is error-free.
- [x] `brew cask style --fix {{cask_file}}` left no offenses.
- [x] The commit message includes the cask’s name and version.